### PR TITLE
Validate Directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2022-04-28
+
+### Added
+
+- Validation can be done on all OOXML files in a single directory or recursively through all child directories
+
 ## [1.1.0] - 2022-04-11
 
 ### Added

--- a/OOXMLValidatorCLI/Classes/DefaultFileService.cs
+++ b/OOXMLValidatorCLI/Classes/DefaultFileService.cs
@@ -1,0 +1,13 @@
+﻿using OOXMLValidatorCLI.Interfaces;
+using System.IO;
+
+namespace OOXMLValidatorCLI.Classes
+{
+    public class DefaultFileService : IFileService
+    {
+        public FileAttributes GetAttributes(string path)
+        {
+            return File.GetAttributes(path);
+        }
+    }
+}

--- a/OOXMLValidatorCLI/Classes/DirectoryService.cs
+++ b/OOXMLValidatorCLI/Classes/DirectoryService.cs
@@ -1,0 +1,23 @@
+﻿using OOXMLValidatorCLI.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OOXMLValidatorCLI.Classes
+{
+    internal class DirectoryService : IDirectoryService
+    {
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateFiles(path, searchPattern, searchOption);
+        }
+
+        public string[] GetFiles(string path)
+        {
+            return Directory.GetFiles(path);
+        }
+    }
+}

--- a/OOXMLValidatorCLI/Classes/FileService.cs
+++ b/OOXMLValidatorCLI/Classes/FileService.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace OOXMLValidatorCLI.Classes
 {
-    public class DefaultFileService : IFileService
+    public class FileService : IFileService
     {
         public FileAttributes GetAttributes(string path)
         {

--- a/OOXMLValidatorCLI/Classes/FunctionUtils.cs
+++ b/OOXMLValidatorCLI/Classes/FunctionUtils.cs
@@ -82,7 +82,7 @@ namespace OOXMLValidatorCLI.Classes
             return _documentUtils.Validate(doc, OfficeVersion);
         }
 
-        public object GetValidationErrors(Tuple<bool, IEnumerable<ValidationErrorInfo>> validationInfo, string filePath, bool returnXml)
+        public object GetValidationErrorsData(Tuple<bool, IEnumerable<ValidationErrorInfo>> validationInfo, string filePath, bool returnXml)
         {
             if (!returnXml)
             {

--- a/OOXMLValidatorCLI/Classes/FunctionUtils.cs
+++ b/OOXMLValidatorCLI/Classes/FunctionUtils.cs
@@ -29,15 +29,8 @@ namespace OOXMLValidatorCLI.Classes
             _fileFormatVersions = null;
         }
 
-        public OpenXmlPackage GetDocument(string filePath)
+        public OpenXmlPackage GetDocument(string filePath, string fileExtension)
         {
-            string fileExtension = filePath.Substring(Math.Max(0, filePath.Length - 4)).ToLower();
-
-            if (!new string[] { "docx", "docm", "dotm", "dotx", "pptx", "pptm", "potm", "potx", "ppam", "ppsm", "ppsx", "xlsx", "xlsm", "xltm", "xltx", "xlam" }.Contains(fileExtension))
-            {
-                throw new ArgumentException("file must be a .docx, .docm, .dotm, .dotx, .pptx, .pptm, .potm, .potx, .ppam, .ppsm, .ppsx, .xlsx, .xlsm, .xltm, .xltx, or .xlam");
-            }
-
             OpenXmlPackage doc = null;
 
             switch (fileExtension)

--- a/OOXMLValidatorCLI/Classes/FunctionUtils.cs
+++ b/OOXMLValidatorCLI/Classes/FunctionUtils.cs
@@ -35,26 +35,26 @@ namespace OOXMLValidatorCLI.Classes
 
             switch (fileExtension)
             {
-               case ".docx":
-               case ".docm":
-               case ".dotm":
-               case ".dotx":
+                case ".docx":
+                case ".docm":
+                case ".dotm":
+                case ".dotx":
                     doc = _documentUtils.OpenWordprocessingDocument(filePath);
                     break;
-               case ".pptx":
-               case ".pptm":
-               case ".potm":
-               case ".potx":
-               case ".ppam":
-               case ".ppsm":
-               case ".ppsx":
+                case ".pptx":
+                case ".pptm":
+                case ".potm":
+                case ".potx":
+                case ".ppam":
+                case ".ppsm":
+                case ".ppsx":
                     doc = _documentUtils.OpenPresentationDocument(filePath);
                     break;
-               case ".xlsx":
-               case ".xlsm":
-               case ".xltm":
-               case ".xltx":
-               case ".xlam":
+                case ".xlsx":
+                case ".xlsm":
+                case ".xltm":
+                case ".xltx":
+                case ".xlam":
                     doc = _documentUtils.OpenSpreadsheetDocument(filePath);
                     break;
                 default:

--- a/OOXMLValidatorCLI/Classes/FunctionUtils.cs
+++ b/OOXMLValidatorCLI/Classes/FunctionUtils.cs
@@ -35,26 +35,26 @@ namespace OOXMLValidatorCLI.Classes
 
             switch (fileExtension)
             {
-                case "docx":
-                case "docm":
-                case "dotm":
-                case "dotx":
+               case ".docx":
+               case ".docm":
+               case ".dotm":
+               case ".dotx":
                     doc = _documentUtils.OpenWordprocessingDocument(filePath);
                     break;
-                case "pptx":
-                case "pptm":
-                case "potm":
-                case "potx":
-                case "ppam":
-                case "ppsm":
-                case "ppsx":
+               case ".pptx":
+               case ".pptm":
+               case ".potm":
+               case ".potx":
+               case ".ppam":
+               case ".ppsm":
+               case ".ppsx":
                     doc = _documentUtils.OpenPresentationDocument(filePath);
                     break;
-                case "xlsx":
-                case "xlsm":
-                case "xltm":
-                case "xltx":
-                case "xlam":
+               case ".xlsx":
+               case ".xlsm":
+               case ".xltm":
+               case ".xltx":
+               case ".xlam":
                     doc = _documentUtils.OpenSpreadsheetDocument(filePath);
                     break;
                 default:

--- a/OOXMLValidatorCLI/Classes/Validate.cs
+++ b/OOXMLValidatorCLI/Classes/Validate.cs
@@ -1,8 +1,12 @@
 ﻿using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
+using Newtonsoft.Json;
 using OOXMLValidatorCLI.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 
 namespace OOXMLValidatorCLI.Classes
 {
@@ -14,15 +18,84 @@ namespace OOXMLValidatorCLI.Classes
         {
             _functionUtils = functionUtils;
         }
-        public object OOXML(string filePath, string format, bool? returnXml)
+        public object OOXML(string filePath, string format, bool returnXml = false)
         {
+
             _functionUtils.SetOfficeVersion(format);
 
-            OpenXmlPackage doc = _functionUtils.GetDocument(filePath);
+            FileAttributes fileAttributes = File.GetAttributes(filePath);
 
-            Tuple<bool, IEnumerable<ValidationErrorInfo>> validationErrorInfos = _functionUtils.GetValidationErrors(doc);
+            if (fileAttributes.HasFlag(FileAttributes.Directory))
+            {
+                IEnumerable<string> files = Directory.GetFiles(filePath);
+                XDocument xDocument = new XDocument(new XElement("Document"));
+                List<object> validationErrorList = new List<object>();
 
-            return _functionUtils.GetValidationErrors(validationErrorInfos, filePath, returnXml ?? false);
+
+                foreach (string file in files)
+                {
+                    string fileExtension = file.Substring(Math.Max(0, file.Length - 4)).ToLower();
+
+                    Tuple<bool, IEnumerable<ValidationErrorInfo>> validationErrorInfos = _getValidationErrors(file, fileExtension, true);
+
+                    if (validationErrorInfos != null)
+                    {
+                        var data = _functionUtils.GetValidationErrors(validationErrorInfos, file, returnXml);
+
+                        if (returnXml)
+                        {
+                            xDocument.Root.Add((data as XDocument).Root);
+                        }
+                        else
+                        {
+                            var errorList = new { FilePath = file, ValidationErrors = data };
+
+                            validationErrorList.Add(errorList);
+                        }
+                    }
+                }
+
+                return returnXml ? xDocument : JsonConvert.SerializeObject(
+                                                validationErrorList,
+                                                Formatting.None,
+                                                new JsonSerializerSettings()
+                                                {
+                                                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                                                }
+                                            ); ;
+            }
+            else
+            {
+                string fileExtension = filePath.Substring(Math.Max(0, filePath.Length - 4)).ToLower();
+                Tuple<bool, IEnumerable<ValidationErrorInfo>> validationErrorInfos = _getValidationErrors(filePath, fileExtension, false);
+
+                return _functionUtils.GetValidationErrors(validationErrorInfos, filePath, returnXml);
+            }
+
+        }
+
+        private Tuple<bool, IEnumerable<ValidationErrorInfo>> _getValidationErrors(string filePath, string fileExtension, bool ignoreInvalidFiles)
+        {
+            FileAttributes fileAttributes = File.GetAttributes(filePath);
+
+            if (
+                fileAttributes.HasFlag(FileAttributes.Directory) ||
+                !new string[] { "docx", "docm", "dotm", "dotx", "pptx", "pptm", "potm", "potx", "ppam", "ppsm", "ppsx", "xlsx", "xlsm", "xltm", "xltx", "xlam" }.Contains(fileExtension)
+            )
+            {
+                if (!ignoreInvalidFiles)
+                {
+                    throw new ArgumentException("file must be a .docx, .docm, .dotm, .dotx, .pptx, .pptm, .potm, .potx, .ppam, .ppsm, .ppsx, .xlsx, .xlsm, .xltm, .xltx, or .xlam");
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            OpenXmlPackage doc = _functionUtils.GetDocument(filePath, fileExtension);
+
+            return _functionUtils.GetValidationErrors(doc);
         }
     }
 }

--- a/OOXMLValidatorCLI/Interfaces/IDirectoryService.cs
+++ b/OOXMLValidatorCLI/Interfaces/IDirectoryService.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OOXMLValidatorCLI.Interfaces
+{
+    public interface IDirectoryService
+    {
+        IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
+        string[] GetFiles(string path);
+    }
+}

--- a/OOXMLValidatorCLI/Interfaces/IFileService.cs
+++ b/OOXMLValidatorCLI/Interfaces/IFileService.cs
@@ -1,0 +1,9 @@
+﻿using System.IO;
+
+namespace OOXMLValidatorCLI.Interfaces
+{
+    public interface IFileService
+    {
+        public FileAttributes GetAttributes(string path);
+    }
+}

--- a/OOXMLValidatorCLI/Interfaces/IFunctionUtils.cs
+++ b/OOXMLValidatorCLI/Interfaces/IFunctionUtils.cs
@@ -9,7 +9,7 @@ namespace OOXMLValidatorCLI.Interfaces
     {
         FileFormatVersions OfficeVersion { get; }
         void SetOfficeVersion(string version);
-        OpenXmlPackage GetDocument(string filePath);
+        OpenXmlPackage GetDocument(string filePath, string fileExtension);
         Tuple<bool, IEnumerable<ValidationErrorInfo>> GetValidationErrors(OpenXmlPackage doc);
         object GetValidationErrors(Tuple<bool, IEnumerable<ValidationErrorInfo>> data, string filePath, bool returnXml);
     }

--- a/OOXMLValidatorCLI/Interfaces/IFunctionUtils.cs
+++ b/OOXMLValidatorCLI/Interfaces/IFunctionUtils.cs
@@ -11,6 +11,6 @@ namespace OOXMLValidatorCLI.Interfaces
         void SetOfficeVersion(string version);
         OpenXmlPackage GetDocument(string filePath, string fileExtension);
         Tuple<bool, IEnumerable<ValidationErrorInfo>> GetValidationErrors(OpenXmlPackage doc);
-        object GetValidationErrors(Tuple<bool, IEnumerable<ValidationErrorInfo>> data, string filePath, bool returnXml);
+        object GetValidationErrorsData(Tuple<bool, IEnumerable<ValidationErrorInfo>> data, string filePath, bool returnXml);
     }
 }

--- a/OOXMLValidatorCLI/Interfaces/IValidate.cs
+++ b/OOXMLValidatorCLI/Interfaces/IValidate.cs
@@ -2,6 +2,6 @@
 {
     public interface IValidate
     {
-        object OOXML(string filePath, string format, bool returnXml);
+        object OOXML(string filePath, string format, bool returnXml, bool recursive);
     }
 }

--- a/OOXMLValidatorCLI/Interfaces/IValidate.cs
+++ b/OOXMLValidatorCLI/Interfaces/IValidate.cs
@@ -2,6 +2,6 @@
 {
     public interface IValidate
     {
-        object OOXML(string filePath, string format, bool? returnXml);
+        object OOXML(string filePath, string format, bool returnXml);
     }
 }

--- a/OOXMLValidatorCLI/OOXMLValidatorCLI.csproj
+++ b/OOXMLValidatorCLI/OOXMLValidatorCLI.csproj
@@ -7,6 +7,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/mikeebowen/OOXML-Validator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <Version>$(VersionPrefix)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OOXMLValidatorCLI/OOXMLValidatorCLI.csproj
+++ b/OOXMLValidatorCLI/OOXMLValidatorCLI.csproj
@@ -7,7 +7,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/mikeebowen/OOXML-Validator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>$(VersionPrefix)</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OOXMLValidatorCLI/Program.cs
+++ b/OOXMLValidatorCLI/Program.cs
@@ -61,7 +61,7 @@ namespace OOXMLValidatorCLI
                 returnXml = args[1] == "--xml" || args[2] == "--xml" ? true : false;
             }
 
-            object validationErrors = validate.OOXML(xmlPath, version, returnXml);
+            object validationErrors = validate.OOXML(xmlPath, version, returnXml ?? false);
 
             Console.Write(validationErrors);
         }

--- a/OOXMLValidatorCLI/Program.cs
+++ b/OOXMLValidatorCLI/Program.cs
@@ -11,14 +11,17 @@ namespace OOXMLValidatorCLI
         private static void Main(string[] args)
         {
             // set up DI
-            var collection = new ServiceCollection();
+            ServiceCollection collection = new ServiceCollection();
             collection.AddScoped<IValidate, Validate>();
             collection.AddScoped<IFunctionUtils, FunctionUtils>();
             collection.AddScoped<IDocumentUtils, DocumentUtils>();
-            collection.AddSingleton<IFileService, DefaultFileService>();
-            var serviceProvider = collection.BuildServiceProvider();
+            collection.AddSingleton<IFileService, FileService>();
+            collection.AddSingleton<IDirectoryService, DirectoryService>();
 
-            var validate = serviceProvider.GetService<IValidate>();
+            ServiceProvider serviceProvider = collection.BuildServiceProvider();
+
+            IValidate validate = serviceProvider.GetService<IValidate>();
+
             string xmlPath;
             bool returnXml = false;
             string version = null;

--- a/OOXMLValidatorCLITests/FunctionUtilsTests.cs
+++ b/OOXMLValidatorCLITests/FunctionUtilsTests.cs
@@ -46,7 +46,7 @@ namespace OOXMLValidatorCLITests
                 .Returns(testDocument);
             FunctionUtils functionUtils = new FunctionUtils(documentUtilsMock);
 
-            var res = functionUtils.GetDocument(testPath);
+            var res = functionUtils.GetDocument(testPath, ".docx");
 
             Assert.AreEqual(res, testDocument);
 
@@ -73,7 +73,7 @@ namespace OOXMLValidatorCLITests
                 .Returns(testDocument);
             FunctionUtils functionUtils = new FunctionUtils(documentMock);
 
-            var res = functionUtils.GetDocument(testPath);
+            var res = functionUtils.GetDocument(testPath, ".pptx");
 
             Assert.AreEqual(res, testDocument);
 
@@ -99,7 +99,7 @@ namespace OOXMLValidatorCLITests
                 .Returns(testDynamic);
             FunctionUtils functionUtils = new FunctionUtils(documentMock);
 
-            var res = functionUtils.GetDocument(testPath);
+            var res = functionUtils.GetDocument(testPath, ".xlsx");
 
             Assert.AreEqual(res, testDynamic);
 

--- a/OOXMLValidatorCLITests/OOXMLValidatorCLITests.csproj
+++ b/OOXMLValidatorCLITests/OOXMLValidatorCLITests.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220401-08" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10-preview-20220414-01" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10-preview-20220414-01" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/OOXMLValidatorCLITests/ValidateTests.cs
+++ b/OOXMLValidatorCLITests/ValidateTests.cs
@@ -8,6 +8,7 @@ using OOXMLValidatorCLI.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Xml.Linq;
 
 namespace OOXMLValidatorCLITests
 {
@@ -15,11 +16,12 @@ namespace OOXMLValidatorCLITests
     public class ValidateTests
     {
         [TestMethod]
-        public void Validate_ShouldCallTheRightMethods()
+        public void Validate_ShouldValidateASingleFile()
         {
             var functionUtilsMock = Mock.Of<IFunctionUtils>();
             var fileServiceMock = Mock.Of<IFileService>();
-            var validate = new Validate(functionUtilsMock, fileServiceMock);
+            var directoryServiceMock = Mock.Of<IDirectoryService>();
+            var validate = new Validate(functionUtilsMock, fileServiceMock, directoryServiceMock);
             string testPath = "path/to/a/file.docx";
             string testFormat = "Office2016";
             MemoryStream memoryStream = new MemoryStream();
@@ -37,11 +39,151 @@ namespace OOXMLValidatorCLITests
                 })
                 .Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(true, validationErrorInfos));
 
-            validate.OOXML(testPath, testFormat, false);
+            validate.OOXML(testPath, testFormat);
 
             Mock.Get(functionUtilsMock).Verify(f => f.SetOfficeVersion(testFormat), Times.Once());
             Mock.Get(functionUtilsMock).Verify(f => f.GetDocument(testPath, ".docx"), Times.Once());
-            Mock.Get(functionUtilsMock).Verify(f => f.GetValidationErrors(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(true, validationErrorInfos), testPath, false), Times.Once());
+            Mock.Get(functionUtilsMock).Verify(f => f.GetValidationErrorsData(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(true, validationErrorInfos), testPath, false), Times.Once());
+        }
+        // file must be have one of these extensions: .docx, .docm, .dotm, .dotx, .pptx, .pptm, .potm, .potx, .ppam, .ppsm, .ppsx, .xlsx, .xlsm, .xltm, .xltx, .xlam
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "file must be have one of these extensions: .docx, .docm, .dotm, .dotx, .pptx, .pptm, .potm, .potx, .ppam, .ppsm, .ppsx, .xlsx, .xlsm, .xltm, .xltx, .xlam")]
+        public void Validate_ShouldThrowAnExceptionWithInvalidFileType()
+        {
+            var functionUtilsMock = Mock.Of<IFunctionUtils>();
+            var fileServiceMock = Mock.Of<IFileService>();
+            var directoryServiceMock = Mock.Of<IDirectoryService>();
+            var validate = new Validate(functionUtilsMock, fileServiceMock, directoryServiceMock);
+            string testPath = "path/to/a/file.foo";
+            string testFormat = "Office2016";
+
+            validate.OOXML(testPath, testFormat);
+            Mock.Get(fileServiceMock).Setup(f => f.GetAttributes(testPath)).Returns(FileAttributes.Normal);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldValidateAFolderAndReturnJson()
+        {
+            var functionUtilsMock = Mock.Of<IFunctionUtils>();
+            var fileServiceMock = Mock.Of<IFileService>();
+            var directoryServiceMock = Mock.Of<IDirectoryService>();
+            var validate = new Validate(functionUtilsMock, fileServiceMock, directoryServiceMock);
+            string testPath = "path/to/files/";
+            string testFormat = null;
+            MemoryStream memoryStream = new MemoryStream();
+            using WordprocessingDocument testWordDoc = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
+            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            Mock.Get(fileServiceMock).Setup(f => f.GetAttributes(testPath)).Returns(FileAttributes.Directory);
+            Mock.Get(directoryServiceMock).Setup(d => d.GetFiles(testPath)).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
+            Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), It.IsAny<string>())).Returns(testWordDoc);
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(false, validationErrorInfos));
+
+            object validationErrors = validate.OOXML(testPath, testFormat, false, false);
+            Assert.IsNotNull(validationErrors);
+            Assert.AreEqual(validationErrors, "[{\"FilePath\":\"taco.docx\",\"ValidationErrors\":null},{\"FilePath\":\"cat.pptx\",\"ValidationErrors\":null},{\"FilePath\":\"foo.xlsx\",\"ValidationErrors\":null},{\"FilePath\":\"bar.docm\",\"ValidationErrors\":null}]");
+        }
+
+
+        [TestMethod]
+        public void Validate_ShouldValidateAFolderAndReturnXml()
+        {
+            var functionUtilsMock = Mock.Of<IFunctionUtils>();
+            var fileServiceMock = Mock.Of<IFileService>();
+            var directoryServiceMock = Mock.Of<IDirectoryService>();
+            var validate = new Validate(functionUtilsMock, fileServiceMock, directoryServiceMock);
+            string testPath = "path/to/files/";
+            string testFormat = null;
+            MemoryStream memoryStream = new MemoryStream();
+            using WordprocessingDocument testWordDoc = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
+            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            XDocument testXDocument = new XDocument(new XElement("Document"));
+            XElement testXml = new XElement("KittyErrorInfoList");
+            testXml.Add(
+                        new XElement("KittyErrorInfo",
+                            new XElement("Description", "The cat peed on the carpet"),
+                            new XElement("Path", "office/carpet"),
+                            new XElement("Id", "305"),
+                            new XElement("ErrorType", "KittyPee")
+                        )
+                    );
+
+            for (int i = 0; i < 4; i++)
+            {
+                testXDocument.Root.Add(XElement.Parse(testXml.ToString()));
+            }
+
+
+            Mock.Get(fileServiceMock).Setup(f => f.GetAttributes(testPath)).Returns(FileAttributes.Directory);
+            Mock.Get(directoryServiceMock).Setup(d => d.GetFiles(testPath)).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
+            Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), It.IsAny<string>())).Returns(testWordDoc);
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(false, validationErrorInfos));
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrorsData(It.IsAny<Tuple<bool, IEnumerable<ValidationErrorInfo>>>(), It.IsAny<string>(), It.IsAny<bool>())).Returns(new XDocument(testXml));
+
+            object validationErrorXml = validate.OOXML(testPath, testFormat, true, false);
+
+            Assert.IsNotNull(validationErrorXml);
+            Assert.AreEqual(validationErrorXml.ToString(), testXDocument.ToString());
+        }
+
+        [TestMethod]
+        public void Validate_ShouldTestRecursivelyWithFlag()
+        {
+            var functionUtilsMock = Mock.Of<IFunctionUtils>();
+            var fileServiceMock = Mock.Of<IFileService>();
+            var directoryServiceMock = Mock.Of<IDirectoryService>();
+            var validate = new Validate(functionUtilsMock, fileServiceMock, directoryServiceMock);
+            string testPath = "path/to/files/";
+            string testFormat = null;
+            MemoryStream memoryStream = new MemoryStream();
+            using WordprocessingDocument testWordDoc = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
+            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            Mock.Get(fileServiceMock).Setup(f => f.GetAttributes(testPath)).Returns(FileAttributes.Directory);
+            Mock.Get(directoryServiceMock).Setup(d => d.GetFiles(testPath)).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
+            Mock.Get(directoryServiceMock).Setup(d => d.EnumerateFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchOption>())).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
+            Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), It.IsAny<string>())).Returns(testWordDoc);
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(false, validationErrorInfos));
+
+            object validationErrors = validate.OOXML(testPath, testFormat, false, true);
+            Assert.IsNotNull(validationErrors);
+            Assert.AreEqual(validationErrors, "[{\"FilePath\":\"taco.docx\",\"ValidationErrors\":null},{\"FilePath\":\"cat.pptx\",\"ValidationErrors\":null},{\"FilePath\":\"foo.xlsx\",\"ValidationErrors\":null},{\"FilePath\":\"bar.docm\",\"ValidationErrors\":null}]");
+            Mock.Get(directoryServiceMock).Verify(d => d.EnumerateFiles(testPath, "*.*", SearchOption.AllDirectories), Times.Once);
+            Mock.Get(directoryServiceMock).Verify(d => d.GetFiles(testPath), Times.Never);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldNotTestFilesRecursivelyWithouFlag()
+        {
+            var functionUtilsMock = Mock.Of<IFunctionUtils>();
+            var fileServiceMock = Mock.Of<IFileService>();
+            var directoryServiceMock = Mock.Of<IDirectoryService>();
+            var validate = new Validate(functionUtilsMock, fileServiceMock, directoryServiceMock);
+            string testPath = "path/to/files/";
+            string testFormat = null;
+            MemoryStream memoryStream = new MemoryStream();
+            using WordprocessingDocument testWordDoc = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
+            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            Mock.Get(fileServiceMock).Setup(f => f.GetAttributes(testPath)).Returns(FileAttributes.Directory);
+            Mock.Get(directoryServiceMock).Setup(d => d.GetFiles(testPath)).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
+            Mock.Get(directoryServiceMock).Setup(d => d.EnumerateFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchOption>())).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
+            Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), It.IsAny<string>())).Returns(testWordDoc);
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(false, validationErrorInfos));
+
+            object validationErrors = validate.OOXML(testPath, testFormat, false, false);
+            Assert.IsNotNull(validationErrors);
+            Assert.AreEqual(validationErrors, "[{\"FilePath\":\"taco.docx\",\"ValidationErrors\":null},{\"FilePath\":\"cat.pptx\",\"ValidationErrors\":null},{\"FilePath\":\"foo.xlsx\",\"ValidationErrors\":null},{\"FilePath\":\"bar.docm\",\"ValidationErrors\":null}]");
+            Mock.Get(directoryServiceMock).Verify(d => d.EnumerateFiles(testPath, "*.*", SearchOption.AllDirectories), Times.Never);
+            Mock.Get(directoryServiceMock).Verify(d => d.GetFiles(testPath), Times.Once);
         }
     }
 }

--- a/OOXMLValidatorCLITests/ValidateTests.cs
+++ b/OOXMLValidatorCLITests/ValidateTests.cs
@@ -18,7 +18,8 @@ namespace OOXMLValidatorCLITests
         public void Validate_ShouldCallTheRightMethods()
         {
             var functionUtilsMock = Mock.Of<IFunctionUtils>();
-            var validate = new Validate(functionUtilsMock);
+            var fileServiceMock = Mock.Of<IFileService>();
+            var validate = new Validate(functionUtilsMock, fileServiceMock);
             string testPath = "path/to/a/file.docx";
             string testFormat = "Office2016";
             MemoryStream memoryStream = new MemoryStream();
@@ -28,7 +29,7 @@ namespace OOXMLValidatorCLITests
 
             IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
 
-            Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>())).Returns(testWordDoc);
+            Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), ".docx")).Returns(testWordDoc);
             Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>()))
                 .Callback<dynamic>(o =>
                 {
@@ -39,7 +40,7 @@ namespace OOXMLValidatorCLITests
             validate.OOXML(testPath, testFormat, false);
 
             Mock.Get(functionUtilsMock).Verify(f => f.SetOfficeVersion(testFormat), Times.Once());
-            Mock.Get(functionUtilsMock).Verify(f => f.GetDocument(testPath), Times.Once());
+            Mock.Get(functionUtilsMock).Verify(f => f.GetDocument(testPath, ".docx"), Times.Once());
             Mock.Get(functionUtilsMock).Verify(f => f.GetValidationErrors(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(true, validationErrorInfos), testPath, false), Times.Once());
         }
     }

--- a/README.md
+++ b/README.md
@@ -8,16 +8,23 @@ The OOXML Validator is a .NET CLI package which validates Open Office XML files 
 
 ## How is it used?
 
-The OOXML Validator CLI accepts 1 required and 2 optional parameters.
+The OOXML Validator CLI accepts 1 required and 3 optional parameters. The first argument must be the file or directory path, the order of the other 3 arguments doesn't matter.
 
 Argument Order | Type | Value | Required/Optional
 ---|---|---|---
-First | string | The absolute path to the file to validate | Required
+First | string | The absolute path to the file or folder to validate | Required
 Second | string | The version of Office to validate against* | Optional
 Third | string | If the value is `--xml`, cli will return xml | Optional
+Fourth | string | If the value is `--recursive` or `-r` validates files recursively through all folders\** | Optional
 
 \* Must be one of these: `Office2007`, `Office2010`, `Office2013`, `Office2016`, `Office2019`, `Office2021`, `Microsoft365`. Defaults to `Microsoft365`
+
+\** Only valid if the path passed is a directory and not a file, otherwise it is ignored
 
 ## XML vs JSON
 
 XML and JSON both return a list of validation errors. In addition to the validation error list, the XML data has 2 attributes: `FilePath` and `IsStrict`. FilePath is the path to the file that was validated and IsStrict is true if the document is saved in strict mode and false otherwise.
+
+## Validating Directories
+
+If the first argument passed is a directory path, then all Office Open XML files in the directory are validated. Non-OOXML files are ignored. If the `-r` or `--recursive` flags are passed then all directories are validated recursively.


### PR DESCRIPTION
Allows for examining all OOXML files in a single directory or recursively through all child directories.