### PR TITLE
Handle OpenXmlPackageException Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2022-07-27
+
+## Added
+
+- Returned XML data returns list of `<File />` elements with a child `<ValidationErrorInfoList />` element, instead of list of `<ValidationErrorInfoList />` elements.
+
+## Fixed
+
+- If a file cannot be opened by the Validator, a `<ValidationErrorInfoInternal />` element is added with the error message.
+
 ## [1.2.0] - 2022-04-28
 
 ### Added

--- a/OOXMLValidatorCLI/Classes/DocumentUtils.cs
+++ b/OOXMLValidatorCLI/Classes/DocumentUtils.cs
@@ -4,6 +4,7 @@ using DocumentFormat.OpenXml.Validation;
 using OOXMLValidatorCLI.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OOXMLValidatorCLI.Classes
 {
@@ -21,12 +22,19 @@ namespace OOXMLValidatorCLI.Classes
         {
             return SpreadsheetDocument.Open(filePath, false);
         }
-        public Tuple<bool, IEnumerable<ValidationErrorInfo>> Validate(OpenXmlPackage doc, FileFormatVersions version)
+        public Tuple<bool, IEnumerable<ValidationErrorInfoInternal>> Validate(OpenXmlPackage doc, FileFormatVersions version)
         {
             OpenXmlValidator openXmlValidator = new OpenXmlValidator(version);
             bool isStrict = doc.StrictRelationshipFound;
-            IEnumerable<ValidationErrorInfo> errors = openXmlValidator.Validate(doc);
-            return new Tuple<bool, IEnumerable<ValidationErrorInfo>>(isStrict, errors);
+            IEnumerable<ValidationErrorInfoInternal> errors = openXmlValidator.Validate(doc).Select(e => new ValidationErrorInfoInternal
+            {
+                ErrorType = e.ErrorType.ToString(),
+                Description = e.Description,
+                Path = e.Path.ToString(),
+                Id = e.Id.ToString()
+            });
+
+            return new Tuple<bool, IEnumerable<ValidationErrorInfoInternal>>(isStrict, errors);
         }
     }
 }

--- a/OOXMLValidatorCLI/Classes/FunctionUtils.cs
+++ b/OOXMLValidatorCLI/Classes/FunctionUtils.cs
@@ -108,18 +108,32 @@ namespace OOXMLValidatorCLI.Classes
             }
             else
             {
-                XElement element = new XElement("ValidationErrorInfoList");
+                XElement element;
+                ValidationErrorInfoInternal first = validationInfo.Item2.FirstOrDefault();
 
-                foreach (ValidationErrorInfoInternal validationErrorInfo in validationInfo.Item2)
+                if (first?.ErrorType == "OpenXmlPackageException")
                 {
-                    element.Add(
-                        new XElement("ValidationErrorInfo",
-                            new XElement("Description", validationErrorInfo.Description),
-                            new XElement("Path", validationErrorInfo.Path),
-                            new XElement("Id", validationErrorInfo.Id),
-                            new XElement("ErrorType", validationErrorInfo.ErrorType)
+                    element = new XElement("Exceptions",
+                        new XElement("OpenXmlPackageException",
+                            new XElement("Message", first.Description)
                         )
                     );
+                }
+                else
+                {
+                    element = new XElement("ValidationErrorInfoList");
+
+                    foreach (ValidationErrorInfoInternal validationErrorInfo in validationInfo.Item2)
+                    {
+                        element.Add(
+                            new XElement("ValidationErrorInfo",
+                                new XElement("Description", validationErrorInfo.Description),
+                                new XElement("Path", validationErrorInfo.Path),
+                                new XElement("Id", validationErrorInfo.Id),
+                                new XElement("ErrorType", validationErrorInfo.ErrorType)
+                            )
+                        );
+                    }
                 }
 
                 XElement xml = new XElement("File", element);

--- a/OOXMLValidatorCLI/Classes/FunctionUtils.cs
+++ b/OOXMLValidatorCLI/Classes/FunctionUtils.cs
@@ -77,18 +77,18 @@ namespace OOXMLValidatorCLI.Classes
             }
         }
 
-        public Tuple<bool, IEnumerable<ValidationErrorInfo>> GetValidationErrors(OpenXmlPackage doc)
+        public Tuple<bool, IEnumerable<ValidationErrorInfoInternal>> GetValidationErrors(OpenXmlPackage doc)
         {
             return _documentUtils.Validate(doc, OfficeVersion);
         }
 
-        public object GetValidationErrorsData(Tuple<bool, IEnumerable<ValidationErrorInfo>> validationInfo, string filePath, bool returnXml)
+        public object GetValidationErrorsData(Tuple<bool, IEnumerable<ValidationErrorInfoInternal>> validationInfo, string filePath, bool returnXml)
         {
             if (!returnXml)
             {
                 List<dynamic> res = new List<dynamic>();
 
-                foreach (ValidationErrorInfo validationErrorInfo in validationInfo.Item2)
+                foreach (ValidationErrorInfoInternal validationErrorInfo in validationInfo.Item2)
                 {
                     dynamic dyno = new ExpandoObject();
                     dyno.Description = validationErrorInfo.Description;
@@ -108,13 +108,11 @@ namespace OOXMLValidatorCLI.Classes
             }
             else
             {
-                XElement xml = new XElement("ValidationErrorInfoList");
-                xml.SetAttributeValue("FilePath", filePath);
-                xml.SetAttributeValue("IsStrict", validationInfo.Item1);
+                XElement element = new XElement("ValidationErrorInfoList");
 
-                foreach (ValidationErrorInfo validationErrorInfo in validationInfo.Item2)
+                foreach (ValidationErrorInfoInternal validationErrorInfo in validationInfo.Item2)
                 {
-                    xml.Add(
+                    element.Add(
                         new XElement("ValidationErrorInfo",
                             new XElement("Description", validationErrorInfo.Description),
                             new XElement("Path", validationErrorInfo.Path),
@@ -123,6 +121,10 @@ namespace OOXMLValidatorCLI.Classes
                         )
                     );
                 }
+
+                XElement xml = new XElement("File", element);
+                xml.SetAttributeValue("FilePath", filePath);
+                xml.SetAttributeValue("IsStrict", validationInfo.Item1);
 
                 return new XDocument(xml);
             }

--- a/OOXMLValidatorCLI/Classes/ValidationErrorInfoInternal.cs
+++ b/OOXMLValidatorCLI/Classes/ValidationErrorInfoInternal.cs
@@ -1,0 +1,18 @@
+﻿using DocumentFormat.OpenXml.Office.CoverPageProps;
+using DocumentFormat.OpenXml.Validation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OOXMLValidatorCLI.Classes
+{
+    public class ValidationErrorInfoInternal
+    {
+        public string ErrorType { get; set; }
+        public string Description { get; set; }
+        public string Path { get; set; }
+        public string Id { get; set; }
+    }
+}

--- a/OOXMLValidatorCLI/Interfaces/IDocumentUtils.cs
+++ b/OOXMLValidatorCLI/Interfaces/IDocumentUtils.cs
@@ -1,6 +1,7 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
+using OOXMLValidatorCLI.Classes;
 using System;
 using System.Collections.Generic;
 
@@ -11,6 +12,6 @@ namespace OOXMLValidatorCLI.Interfaces
         WordprocessingDocument OpenWordprocessingDocument(string tempFilePath);
         SpreadsheetDocument OpenSpreadsheetDocument(string tempFilePath);
         PresentationDocument OpenPresentationDocument(string tempFilePath);
-        Tuple<bool, IEnumerable<ValidationErrorInfo>> Validate(OpenXmlPackage doc, FileFormatVersions version);
+        Tuple<bool, IEnumerable<ValidationErrorInfoInternal>> Validate(OpenXmlPackage doc, FileFormatVersions version);
     }
 }

--- a/OOXMLValidatorCLI/Interfaces/IFunctionUtils.cs
+++ b/OOXMLValidatorCLI/Interfaces/IFunctionUtils.cs
@@ -1,6 +1,7 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
+using OOXMLValidatorCLI.Classes;
 using System;
 using System.Collections.Generic;
 namespace OOXMLValidatorCLI.Interfaces
@@ -10,7 +11,7 @@ namespace OOXMLValidatorCLI.Interfaces
         FileFormatVersions OfficeVersion { get; }
         void SetOfficeVersion(string version);
         OpenXmlPackage GetDocument(string filePath, string fileExtension);
-        Tuple<bool, IEnumerable<ValidationErrorInfo>> GetValidationErrors(OpenXmlPackage doc);
-        object GetValidationErrorsData(Tuple<bool, IEnumerable<ValidationErrorInfo>> data, string filePath, bool returnXml);
+        Tuple<bool, IEnumerable<ValidationErrorInfoInternal>> GetValidationErrors(OpenXmlPackage doc);
+        object GetValidationErrorsData(Tuple<bool, IEnumerable<ValidationErrorInfoInternal>> data, string filePath, bool returnXml);
     }
 }

--- a/OOXMLValidatorCLI/Interfaces/IValidate.cs
+++ b/OOXMLValidatorCLI/Interfaces/IValidate.cs
@@ -2,6 +2,6 @@
 {
     public interface IValidate
     {
-        object OOXML(string filePath, string format, bool returnXml, bool recursive);
+        object OOXML(string filePath, string format, bool returnXml, bool recursive, bool includeValid);
     }
 }

--- a/OOXMLValidatorCLI/Program.cs
+++ b/OOXMLValidatorCLI/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OOXMLValidatorCLI.Classes;
 using OOXMLValidatorCLI.Interfaces;
 using System;
+using System.Threading;
 
 namespace OOXMLValidatorCLI
 {
@@ -10,65 +11,76 @@ namespace OOXMLValidatorCLI
     {
         private static void Main(string[] args)
         {
-            // set up DI
-            ServiceCollection collection = new ServiceCollection();
-            collection.AddScoped<IValidate, Validate>();
-            collection.AddScoped<IFunctionUtils, FunctionUtils>();
-            collection.AddScoped<IDocumentUtils, DocumentUtils>();
-            collection.AddSingleton<IFileService, FileService>();
-            collection.AddSingleton<IDirectoryService, DirectoryService>();
-
-            ServiceProvider serviceProvider = collection.BuildServiceProvider();
-
-            IValidate validate = serviceProvider.GetService<IValidate>();
-
-            string xmlPath;
-            bool returnXml = false;
-            string version = null;
-            bool recursive = false;
-
-            if (args != null && args.Length > 0)
+            try
             {
-                xmlPath = args[0];
+                // set up DI
+                ServiceCollection collection = new ServiceCollection();
+                collection.AddScoped<IValidate, Validate>();
+                collection.AddScoped<IFunctionUtils, FunctionUtils>();
+                collection.AddScoped<IDocumentUtils, DocumentUtils>();
+                collection.AddSingleton<IFileService, FileService>();
+                collection.AddSingleton<IDirectoryService, DirectoryService>();
 
-                for (int i = 1; i < args.Length; i++)
+                ServiceProvider serviceProvider = collection.BuildServiceProvider();
+
+                IValidate validate = serviceProvider.GetService<IValidate>();
+
+                string xmlPath;
+                bool returnXml = false;
+                string version = null;
+                bool recursive = false;
+                bool includeValid = false;
+
+                if (args != null && args.Length > 0)
                 {
-                    if (Enum.TryParse(args[i], out FileFormatVersions v))
+                    xmlPath = args[0];
+
+                    for (int i = 1; i < args.Length; i++)
                     {
-                        version = args[i];
-                    }
-                    else
-                    {
-                        switch (args[i])
+                        if (Enum.TryParse(args[i], out FileFormatVersions v))
                         {
-                            case "--xml":
-                                returnXml = true;
-                                break;
-                            case "-r":
-                                recursive = true;
-                                break;
-                            case "--recursive":
-                                recursive = true;
-                                break;
-                            default: throw new ArgumentException("Unknown argument", args[i]);
+                            version = args[i];
+                        }
+                        else
+                        {
+                            switch (args[i])
+                            {
+                                case "--xml":
+                                    returnXml = true;
+                                    break;
+                                case "-x":
+                                    returnXml = true;
+                                    break;
+                                case "--recursive":
+                                    recursive = true;
+                                    break;
+                                case "-r":
+                                    recursive = true;
+                                    break;
+                                case "--all":
+                                    includeValid = true;
+                                    break;
+                                case "-a":
+                                    includeValid = true;
+                                    break;
+                                default: throw new ArgumentException("Unknown argument", args[i]);
+                            }
                         }
                     }
                 }
+                else
+                {
+                    throw new ArgumentNullException();
+                }
+
+                object validationErrors = validate.OOXML(xmlPath, version, returnXml, recursive, includeValid);
+
+                Console.Write(validationErrors);
             }
-            else
+            catch (Exception ex)
             {
-                throw new ArgumentNullException();
+                Console.WriteLine(ex.Message);
             }
-
-
-            if (args.Length > 2)
-            {
-                returnXml = args[1] == "--xml" || args[2] == "--xml" ? true : false;
-            }
-
-            object validationErrors = validate.OOXML(xmlPath, version, returnXml, recursive);
-
-            Console.Write(validationErrors);
         }
     }
 }

--- a/OOXMLValidatorCLITests/FunctionUtilsTests.cs
+++ b/OOXMLValidatorCLITests/FunctionUtilsTests.cs
@@ -131,9 +131,9 @@ namespace OOXMLValidatorCLITests
         [TestMethod]
         public void GetValidationErrorsData_ShouldReturnValidJson()
         {
-            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            IEnumerable<ValidationErrorInfoInternal> validationErrorInfos = new List<ValidationErrorInfoInternal>() { new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal() };
             var documentMock = Mock.Of<IDocumentUtils>();
-            string testJson = "\"[{\\\"Description\\\":\\\"\\\",\\\"Path\\\":null,\\\"Id\\\":null,\\\"ErrorType\\\":0},{\\\"Description\\\":\\\"\\\",\\\"Path\\\":null,\\\"Id\\\":null,\\\"ErrorType\\\":0},{\\\"Description\\\":\\\"\\\",\\\"Path\\\":null,\\\"Id\\\":null,\\\"ErrorType\\\":0}]\"";
+            string testJson = "\"[{\\\"Description\\\":null,\\\"Path\\\":null,\\\"Id\\\":null,\\\"ErrorType\\\":null},{\\\"Description\\\":null,\\\"Path\\\":null,\\\"Id\\\":null,\\\"ErrorType\\\":null},{\\\"Description\\\":null,\\\"Path\\\":null,\\\"Id\\\":null,\\\"ErrorType\\\":null}]\"";
 
 
             var functionUtils = new FunctionUtils(documentMock);
@@ -146,9 +146,9 @@ namespace OOXMLValidatorCLITests
         [TestMethod]
         public void GetValidationErrorsData_ShouldReturnValidXml()
         {
-            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            IEnumerable<ValidationErrorInfoInternal> validationErrorInfos = new List<ValidationErrorInfoInternal>() { new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal() };
             var documentMock = Mock.Of<IDocumentUtils>();
-            string xmlString = "<ValidationErrorInfoList FilePath='C:\\test\\file\\path.xlsx' IsStrict='true'><ValidationErrorInfo><Description></Description><Path/><Id/><ErrorType>Schema</ErrorType></ValidationErrorInfo><ValidationErrorInfo><Description></Description><Path/><Id/><ErrorType>Schema</ErrorType></ValidationErrorInfo><ValidationErrorInfo><Description></Description><Path/><Id/><ErrorType>Schema</ErrorType></ValidationErrorInfo></ValidationErrorInfoList>";
+            string xmlString = "<File FilePath=\"C:\\test\\file\\path.xlsx\" IsStrict=\"true\"><ValidationErrorInfoList><ValidationErrorInfo><Description /><Path /><Id /><ErrorType /></ValidationErrorInfo><ValidationErrorInfo><Description /><Path /><Id /><ErrorType /></ValidationErrorInfo><ValidationErrorInfo><Description /><Path /><Id /><ErrorType /></ValidationErrorInfo></ValidationErrorInfoList></File>";
             XDocument xDoc = XDocument.Parse(xmlString);
 
             var functionUtils = new FunctionUtils(documentMock);
@@ -160,7 +160,7 @@ namespace OOXMLValidatorCLITests
         [TestMethod]
         public void GetValidationErrors_ShouldCallValidate()
         {
-            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            IEnumerable<ValidationErrorInfoInternal> validationErrorInfos = new List<ValidationErrorInfoInternal>() { new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal() };
             var testTup = Tuple.Create(true, validationErrorInfos);
             var documentMock = Mock.Of<IDocumentUtils>();
 

--- a/OOXMLValidatorCLITests/ValidateTests.cs
+++ b/OOXMLValidatorCLITests/ValidateTests.cs
@@ -29,7 +29,7 @@ namespace OOXMLValidatorCLITests
 
             memoryStream.Seek(0, SeekOrigin.Begin);
 
-            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            IEnumerable<ValidationErrorInfoInternal> validationErrorInfos = new List<ValidationErrorInfoInternal>() { new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal() };
 
             Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), ".docx")).Returns(testWordDoc);
             Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>()))
@@ -37,13 +37,13 @@ namespace OOXMLValidatorCLITests
                 {
                     Assert.AreEqual(testWordDoc, o);
                 })
-                .Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(true, validationErrorInfos));
+                .Returns(new Tuple<bool, IEnumerable<ValidationErrorInfoInternal>>(true, validationErrorInfos));
 
             validate.OOXML(testPath, testFormat);
 
             Mock.Get(functionUtilsMock).Verify(f => f.SetOfficeVersion(testFormat), Times.Once());
             Mock.Get(functionUtilsMock).Verify(f => f.GetDocument(testPath, ".docx"), Times.Once());
-            Mock.Get(functionUtilsMock).Verify(f => f.GetValidationErrorsData(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(true, validationErrorInfos), testPath, false), Times.Once());
+            Mock.Get(functionUtilsMock).Verify(f => f.GetValidationErrorsData(new Tuple<bool, IEnumerable<ValidationErrorInfoInternal>>(true, validationErrorInfos), testPath, false), Times.Once());
         }
         // file must be have one of these extensions: .docx, .docm, .dotm, .dotx, .pptx, .pptm, .potm, .potx, .ppam, .ppsm, .ppsx, .xlsx, .xlsm, .xltm, .xltx, .xlam
         [TestMethod]
@@ -72,14 +72,14 @@ namespace OOXMLValidatorCLITests
             string testFormat = null;
             MemoryStream memoryStream = new MemoryStream();
             using WordprocessingDocument testWordDoc = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
-            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            IEnumerable<ValidationErrorInfoInternal> validationErrorInfos = new List<ValidationErrorInfoInternal>() { new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal() };
 
             memoryStream.Seek(0, SeekOrigin.Begin);
 
             Mock.Get(fileServiceMock).Setup(f => f.GetAttributes(testPath)).Returns(FileAttributes.Directory);
             Mock.Get(directoryServiceMock).Setup(d => d.GetFiles(testPath)).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
             Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), It.IsAny<string>())).Returns(testWordDoc);
-            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(false, validationErrorInfos));
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfoInternal>>(false, validationErrorInfos));
 
             object validationErrors = validate.OOXML(testPath, testFormat, false, false);
             Assert.IsNotNull(validationErrors);
@@ -98,7 +98,7 @@ namespace OOXMLValidatorCLITests
             string testFormat = null;
             MemoryStream memoryStream = new MemoryStream();
             using WordprocessingDocument testWordDoc = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
-            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            IEnumerable<ValidationErrorInfoInternal> validationErrorInfos = new List<ValidationErrorInfoInternal>() { new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal() };
             memoryStream.Seek(0, SeekOrigin.Begin);
 
             XDocument testXDocument = new XDocument(new XElement("Document"));
@@ -121,8 +121,8 @@ namespace OOXMLValidatorCLITests
             Mock.Get(fileServiceMock).Setup(f => f.GetAttributes(testPath)).Returns(FileAttributes.Directory);
             Mock.Get(directoryServiceMock).Setup(d => d.GetFiles(testPath)).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
             Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), It.IsAny<string>())).Returns(testWordDoc);
-            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(false, validationErrorInfos));
-            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrorsData(It.IsAny<Tuple<bool, IEnumerable<ValidationErrorInfo>>>(), It.IsAny<string>(), It.IsAny<bool>())).Returns(new XDocument(testXml));
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfoInternal>>(false, validationErrorInfos));
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrorsData(It.IsAny<Tuple<bool, IEnumerable<ValidationErrorInfoInternal>>>(), It.IsAny<string>(), It.IsAny<bool>())).Returns(new XDocument(testXml));
 
             object validationErrorXml = validate.OOXML(testPath, testFormat, true, false);
 
@@ -141,7 +141,7 @@ namespace OOXMLValidatorCLITests
             string testFormat = null;
             MemoryStream memoryStream = new MemoryStream();
             using WordprocessingDocument testWordDoc = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
-            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            IEnumerable<ValidationErrorInfoInternal> validationErrorInfos = new List<ValidationErrorInfoInternal>() { new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal() };
 
             memoryStream.Seek(0, SeekOrigin.Begin);
 
@@ -149,7 +149,7 @@ namespace OOXMLValidatorCLITests
             Mock.Get(directoryServiceMock).Setup(d => d.GetFiles(testPath)).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
             Mock.Get(directoryServiceMock).Setup(d => d.EnumerateFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchOption>())).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
             Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), It.IsAny<string>())).Returns(testWordDoc);
-            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(false, validationErrorInfos));
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfoInternal>>(false, validationErrorInfos));
 
             object validationErrors = validate.OOXML(testPath, testFormat, false, true);
             Assert.IsNotNull(validationErrors);
@@ -169,7 +169,7 @@ namespace OOXMLValidatorCLITests
             string testFormat = null;
             MemoryStream memoryStream = new MemoryStream();
             using WordprocessingDocument testWordDoc = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
-            IEnumerable<ValidationErrorInfo> validationErrorInfos = new List<ValidationErrorInfo>() { new ValidationErrorInfo(), new ValidationErrorInfo(), new ValidationErrorInfo() };
+            IEnumerable<ValidationErrorInfoInternal> validationErrorInfos = new List<ValidationErrorInfoInternal>() { new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal(), new ValidationErrorInfoInternal() };
 
             memoryStream.Seek(0, SeekOrigin.Begin);
 
@@ -177,7 +177,7 @@ namespace OOXMLValidatorCLITests
             Mock.Get(directoryServiceMock).Setup(d => d.GetFiles(testPath)).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
             Mock.Get(directoryServiceMock).Setup(d => d.EnumerateFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchOption>())).Returns(new string[] { "taco.docx", "cat.pptx", "foo.xlsx", "bar.docm" });
             Mock.Get(functionUtilsMock).Setup(f => f.GetDocument(It.IsAny<string>(), It.IsAny<string>())).Returns(testWordDoc);
-            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfo>>(false, validationErrorInfos));
+            Mock.Get(functionUtilsMock).Setup(f => f.GetValidationErrors(It.IsAny<OpenXmlPackage>())).Returns(new Tuple<bool, IEnumerable<ValidationErrorInfoInternal>>(false, validationErrorInfos));
 
             object validationErrors = validate.OOXML(testPath, testFormat, false, false);
             Assert.IsNotNull(validationErrors);

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ The OOXML Validator is a .NET CLI package which validates Open Office XML files 
 
 ## How is it used?
 
-The OOXML Validator CLI accepts 1 required and 3 optional parameters. The first argument must be the file or directory path, the order of the other 3 arguments doesn't matter.
+The OOXML Validator CLI accepts 1 required and 4 optional parameters. The first argument must be the file or directory path, the order of the other 4 arguments doesn't matter.
 
 Argument Order | Type | Value | Required/Optional
 ---|---|---|---
 First | string | The absolute path to the file or folder to validate | Required
 Second | string | The version of Office to validate against* | Optional
-Third | string | If the value is `--xml`, cli will return xml | Optional
+Third | string | If the value is `--xml` or `-x`, cli will return xml | Optional
 Fourth | string | If the value is `--recursive` or `-r` validates files recursively through all folders\** | Optional
+Fifth | string | If the value is `--all` or `-a` files without any errors are included in the list. | Optional
 
-\* Must be one of these: `Office2007`, `Office2010`, `Office2013`, `Office2016`, `Office2019`, `Office2021`, `Microsoft365`. Defaults to `Microsoft365`
+\* Must be one of these (case sensitive): `Office2007`, `Office2010`, `Office2013`, `Office2016`, `Office2019`, `Office2021`, `Microsoft365`. Defaults to `Microsoft365`
 
 \** Only valid if the path passed is a directory and not a file, otherwise it is ignored
 


### PR DESCRIPTION
This commit handles when a file cannot be opened because of a OpenXmlPackageException exception. And changes the format of the returned XML.