### PR TITLE
Added `publish.yml` with builds for each environment, also fixing the linux build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: OOXMLValidator Publish
+
+on:
+  push:
+    branches: [main, feature/added-publish-action]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+env:
+  AZURE_FUNCTIONAPP_NAME: OOXMLValidator  # set this to your application's name
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'    # set this to the path to your web app project, defaults to the repository root
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup DotNet 8.x Environment
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.x
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Build/linux-x64
+        run: dotnet publish --framework net8.0 -c Release -r linux-x64 -p:IncludeNativeLibrariesForSelfExtract=true -p:InvariantGlobalization=true OOXMLValidator.sln
+      - name: Build/linux-arm64
+        run: dotnet publish --framework net8.0 -c Release -r linux-arm64 -p:IncludeNativeLibrariesForSelfExtract=true -p:InvariantGlobalization=true OOXMLValidator.sln
+      - name: Build/osx-x64
+        run: dotnet publish --framework net8.0 -c Release -r osx-x64 OOXMLValidator.sln
+      - name: Build/win-x64
+        run: dotnet publish --framework net8.0 -c Release -r win-x64 OOXMLValidator.sln
+
+      - name: Artifacts/linux-x64
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-linux-x64
+          path: ./OOXMLValidatorCLI/bin/Release/net8.0/linux-x64/publish/OOXMLValidatorCLI
+      - name: Artifacts/linux-arm64
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-linux-arm64
+          path: ./OOXMLValidatorCLI/bin/Release/net8.0/linux-arm64/publish/OOXMLValidatorCLI
+      - name: Artifacts/osx-x64
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-osx-x64
+          path: ./OOXMLValidatorCLI/bin/Release/net8.0/osx-x64/publish/OOXMLValidatorCLI
+      - name: Artifacts/win-x64
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-win-x64
+          path: ./OOXMLValidatorCLI/bin/Release/net8.0/win-x64/publish/OOXMLValidatorCLI.exe
+        

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: OOXMLValidator Publish
 
 on:
   push:
-    branches: [main, feature/added-publish-action]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
       - '**.md'
   pull_request:
@@ -14,7 +15,7 @@ env:
   AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'    # set this to the path to your web app project, defaults to the repository root
 
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           name: build-osx-arm64
           path: ./OOXMLValidatorCLI/bin/Release/net8.0/osx-arm64/publish/OOXMLValidatorCLI
-          osx-arm64
       - name: Artifacts/win-x64
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,8 @@ jobs:
         run: dotnet publish --framework net8.0 -c Release -r linux-arm64 -p:IncludeNativeLibrariesForSelfExtract=true -p:InvariantGlobalization=true OOXMLValidator.sln
       - name: Build/osx-x64
         run: dotnet publish --framework net8.0 -c Release -r osx-x64 OOXMLValidator.sln
+      - name: Build/osx-arm64
+        run: dotnet publish --framework net8.0 -c Release -r osx-arm64 OOXMLValidator.sln
       - name: Build/win-x64
         run: dotnet publish --framework net8.0 -c Release -r win-x64 OOXMLValidator.sln
 
@@ -50,6 +52,12 @@ jobs:
         with:
           name: build-osx-x64
           path: ./OOXMLValidatorCLI/bin/Release/net8.0/osx-x64/publish/OOXMLValidatorCLI
+      - name: Artifacts/osx-arm64
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-osx-arm64
+          path: ./OOXMLValidatorCLI/bin/Release/net8.0/osx-arm64/publish/OOXMLValidatorCLI
+          osx-arm64
       - name: Artifacts/win-x64
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
I've added fixes for linux CLI build the fixes were to add `-p:IncludeNativeLibrariesForSelfExtract=true` and `-p:InvariantGlobalization=true` during the build.

 - `linux-x64`
 - `linux-arm64`
 - `osx-x64`
 - `osx-arm64`
 - `win-x64`

I've done a little smoke test for `linux-arm64` (via docker) and `osx-x64` (via macos)

You can see a successful build over at https://github.com/orangemug/OOXML-Validator/actions/runs/9652290583

I'll test a little more tomorrow, but hopefully this should resolve the issues in issue #21 

Questions do you want to run this on every build? or just when new tags get added.

Fixes #21 