### PR TITLE
Added better CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        build_env: ["linux-x64", "linux-arm64", "osx-x64", "osx-arm64", "win-x64"]
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup DotNet 8.x Environment
@@ -27,40 +31,47 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: Build/linux-x64
-        run: dotnet publish --framework net8.0 -c Release -r linux-x64 -p:IncludeNativeLibrariesForSelfExtract=true -p:InvariantGlobalization=true OOXMLValidator.sln
-      - name: Build/linux-arm64
-        run: dotnet publish --framework net8.0 -c Release -r linux-arm64 -p:IncludeNativeLibrariesForSelfExtract=true -p:InvariantGlobalization=true OOXMLValidator.sln
-      - name: Build/osx-x64
-        run: dotnet publish --framework net8.0 -c Release -r osx-x64 OOXMLValidator.sln
-      - name: Build/osx-arm64
-        run: dotnet publish --framework net8.0 -c Release -r osx-arm64 OOXMLValidator.sln
-      - name: Build/win-x64
-        run: dotnet publish --framework net8.0 -c Release -r win-x64 OOXMLValidator.sln
+      - name: Build/${{ matrix.build_env }}
+        run: ./dev.sh build ${{ matrix.build_env }}
 
-      - name: Artifacts/linux-x64
+      - name: Artifacts/${{ matrix.build_env }}
         uses: actions/upload-artifact@v4
         with:
-          name: build-linux-x64
-          path: ./OOXMLValidatorCLI/bin/Release/net8.0/linux-x64/publish/OOXMLValidatorCLI
-      - name: Artifacts/linux-arm64
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-linux-arm64
-          path: ./OOXMLValidatorCLI/bin/Release/net8.0/linux-arm64/publish/OOXMLValidatorCLI
-      - name: Artifacts/osx-x64
-        uses: actions/upload-artifact@v4
+          name: build-${{ matrix.build_env }}
+          path: |
+            ./OOXMLValidatorCLI/bin/Release/net8.0/${{ matrix.build_env }}/publish/OOXMLValidatorCLI
+            ./OOXMLValidatorCLI/bin/Release/net8.0/${{ matrix.build_env }}/publish/OOXMLValidatorCLI.exe
+        
+  publish-test-osx-x64:
+    needs: publish
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: build-osx-x64
-          path: ./OOXMLValidatorCLI/bin/Release/net8.0/osx-x64/publish/OOXMLValidatorCLI
-      - name: Artifacts/osx-arm64
-        uses: actions/upload-artifact@v4
+          path: ./test-ci
+      - run: CI_SHELL_OVERRIDE=test-ci ./dev.sh test osx-x64
+
+  publish-test-linux:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          name: build-osx-arm64
-          path: ./OOXMLValidatorCLI/bin/Release/net8.0/osx-arm64/publish/OOXMLValidatorCLI
-      - name: Artifacts/win-x64
-        uses: actions/upload-artifact@v4
+          name: build-linux-x64
+          path: ./test-ci
+      - run: CI_SHELL_OVERRIDE=test-ci ./dev.sh test linux-x64
+
+  publish-test-windows:
+    needs: publish
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: build-win-x64
-          path: ./OOXMLValidatorCLI/bin/Release/net8.0/win-x64/publish/OOXMLValidatorCLI.exe
-        
+          path: ./test-ci
+      - shell: bash
+        run: CI_SHELL_OVERRIDE=test-ci ./dev.sh test win-x64

--- a/README.md
+++ b/README.md
@@ -29,3 +29,38 @@ XML and JSON both return a list of validation errors. In addition to the validat
 ## Validating Directories
 
 If the first argument passed is a directory path, then all Office Open XML files in the directory are validated. Non-OOXML files are ignored. If the `-r` or `--recursive` flags are passed then all directories are validated recursively.
+
+
+## Development
+You can run some development scripts with
+
+```bash
+./dev.sh help
+# ./dev.sh <command> [build_env]
+# 
+#   help                 show this help message
+#   docker               docker container for development
+#   build <build_env>    build
+#   envs                 show build envs
+#   run <build_env>      run the command line
+# 
+```
+
+To build run the following, replacing `linux-x64` with your environment
+
+```bash
+./dev.sh build linux-x64
+```
+
+Run the executable with
+
+```bash
+./dev.sh run linux-x64 ./test.docx
+```
+
+If you don't want to install `dotnet` just run the following to start a container shell
+
+```bash
+./dev.sh docker
+# root@8b0f1aad055c:/code# [RUN YOUR COMMANDS HERE]
+```

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -e 
+
+build_envs=(
+    linux-x64
+    linux-arm64
+    osx-x64
+    osx-arm64
+    win-x64
+)
+
+help () {
+    cat <<EOF
+$0 <command> [build_env]
+
+  help                 show this help message
+  docker               docker container for development
+  build <build_env>    build
+  envs                 show build envs
+  run <build_env>      run the command line
+
+EOF
+}
+
+if [ "$#" -lt 1 ]; then
+    help
+fi
+
+invalid_env () {
+    echo "Error: '$1' must be one of '${build_envs[@]}'"
+    help
+}
+
+command=$1;
+
+build () {
+    if [ "$#" -ne 1 ]; then
+        echo "Illegal number of parameters"
+        help
+        exit 1
+    fi
+    build_env=$1
+
+    if ! [[ ${build_envs[@]} =~ $build_env ]]; then
+        invalid_env $build_env
+        exit 1
+    fi
+
+    case "$build_env" in
+        "linux-x64")
+            dotnet publish --framework net8.0 -c Release -r linux-x64 -p:IncludeNativeLibrariesForSelfExtract=true -p:InvariantGlobalization=true OOXMLValidator.sln
+            ;;
+        "linux-arm64")
+            dotnet publish --framework net8.0 -c Release -r linux-arm64 -p:IncludeNativeLibrariesForSelfExtract=true -p:InvariantGlobalization=true OOXMLValidator.sln
+            ;;
+        "osx-x64")
+            dotnet publish --framework net8.0 -c Release -r osx-x64 OOXMLValidator.sln
+            ;;
+        "osx-arm64")
+            dotnet publish --framework net8.0 -c Release -r osx-arm64 OOXMLValidator.sln
+            ;;
+        "win-x64")
+            dotnet publish --framework net8.0 -c Release -r win-x64 OOXMLValidator.sln
+            ;;
+    esac
+
+    if ! [[ "$build_env" =~ "win-" ]]; then
+        chmod +x "./OOXMLValidatorCLI/bin/Release/net8.0/${build_env}/publish/OOXMLValidatorCLI"
+    fi
+}
+
+run () {
+    if [ "$#" -lt 1 ]; then
+        echo "Illegal number of parameters"
+        help
+        exit 1
+    fi
+    build_env=$1
+
+    if ! [[ ${build_envs[@]} =~ $build_env ]]; then
+        invalid_env "$build_env"
+        exit 1
+    fi
+
+    if [[ "$build_env" =~ "win-" ]]; then
+        ext=".exe"
+    fi
+
+    "./OOXMLValidatorCLI/bin/Release/net8.0/${build_env}/publish/OOXMLValidatorCLI${ext}" ${*:2}
+    exit 0
+}
+
+test () {
+    if [ "$#" -lt 1 ]; then
+        echo "Illegal number of parameters"
+        help
+        exit 1
+    fi
+    build_env=$1
+
+    if ! [[ ${build_envs[@]} =~ $build_env ]]; then
+        invalid_env "$build_env"
+        exit 1
+    fi
+
+    if [[ "$build_env" =~ "win-" ]]; then
+        ext=".exe"
+    fi
+
+    shell_cmd="./${CI_SHELL_OVERRIDE:-"OOXMLValidatorCLI/bin/Release/net8.0/${build_env}/publish"}/OOXMLValidatorCLI${ext}"
+    echo $shell_cmd
+    chmod +x "${shell_cmd}"
+    
+    output="$($shell_cmd)" 
+    if [[ "$output" == "Value cannot be null." ]]; then
+        echo "success"
+        exit 0
+    else
+        echo "error:"
+        echo "$output"
+        exit 2 
+    fi
+    
+}
+
+envs () {
+    echo "${build_envs[@]}"
+}
+
+docker () {
+    if [[ "$DOCKER_RUNNING" == "true" ]]; then
+        echo "Error: Already running inside container"
+        help
+        exit 1
+    fi
+
+    cleanup() {
+        rm .build-files/Dockerfile || true
+        rm .build-files/compose.yaml || true
+        rmdir .build-files || true
+    }
+    trap cleanup EXIT
+
+    mkdir .build-files
+    cat << EOF > .build-files/Dockerfile
+FROM ubuntu
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y dotnet-sdk-8.0
+
+WORKDIR /code
+EOF
+
+    cat << EOF > .build-files/compose.yaml
+services:
+  dev:
+    build:
+      dockerfile: ./Dockerfile
+    environment:
+      - DOCKER_RUNNING=true
+    volumes:
+      - ../:/code
+EOF
+
+    docker-compose -f .build-files/compose.yaml run dev bash
+}
+
+case "$command" in
+    "docker")
+        docker
+        ;;
+    "build")
+        build $2
+        ;;
+    "run")
+        run ${*:2}
+        ;;
+    "envs")
+        envs
+        ;;
+    "help")
+        help
+        ;;
+    "test")
+        test $2
+        ;;
+esac


### PR DESCRIPTION
This PR adds better CI, dev scripts and testing of published output.

There is a test run over https://github.com/orangemug/OOXML-Validator/actions/runs/9669239324 to view, results shown below

<img width="692" alt="Screenshot 2024-06-25 at 21 37 06" src="https://github.com/mikeebowen/OOXML-Validator/assets/235915/5598a438-57ba-46bd-8264-f1072a0184b3">

The `publish-test-*` scripts, run the script and test for the default output `"Value cannot be null."` on the target environment.

There are also now some development scripts, which get used in CI also (and by me when developing this)

> ## Development
> You can run some development scripts with
> 
> ```bash
> ./dev.sh help
> # ./dev.sh <command> [build_env]
> # 
> #   help                 show this help message
> #   docker               docker container for development
> #   build <build_env>    build
> #   envs                 show build envs
> #   run <build_env>      run the command line
> # 
> ```
> 
> To build run the following, replacing `linux-x64` with your environment
> 
> ```bash
> ./dev.sh build linux-x64
> ```
> 
> Run the executable with
> 
> ```bash
> ./dev.sh run linux-x64 ./test.docx
> ```
> 
> If you don't want to install `dotnet` just run the following to start a container shell
> 
> ```bash
> ./dev.sh docker
> # root@8b0f1aad055c:/code# [RUN YOUR COMMANDS HERE]
> ```
